### PR TITLE
updating DAGs mgnmt task to install DAG pip libraries via Pipenv or Pip requirements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ airflow_pip_custom_version_install: False
 # Installation vars
 airflow_user_name: 'airflow'
 airflow_user_group: "{{ airflow_user_name }}"
-airflow_user_shell: '/bin/false'
+airflow_user_shell: '/bin/bash'
 airflow_user_home_path: '/var/lib/airflow'
 airflow_user_home_mode: '0700'
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ airflow_virtualenv_mode: "0755"
 airflow_python_version: "{{ _airflow_python_version }}"
 airflow_packages:
   - name: 'pip'
-    version: '10.0.1'
+    version: '19.0.3'
   - name: 'setuptools'
     version: '39.1.0'
   - name: 'GitPython'
@@ -46,6 +46,7 @@ airflow_packages:
     version: '0.28.2'
   - name: 'apache-airflow'
     version: '1.9.0'
+  - name: 'pipenv'
 airflow_extra_packages:
   - name: 'apache-airflow[crypto]'
 
@@ -271,3 +272,5 @@ dags_git_repositories:
   - repo: "https://github.com/tulibraries/cob_datapipeline.git"
     dest_folder: "cob_datapipeline"
     branch_or_release: "master"
+    pipfile: true
+    pip_requirements: false

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -29,7 +29,7 @@ def test_airflow_user(host):
     assert airflow_user.exists is True
     assert airflow_user.group == 'airflow'
     assert airflow_user.home == '/var/lib/airflow'
-    assert airflow_user.shell == '/bin/false'
+    assert airflow_user.shell == '/bin/bash'
 
 
 def test_airflow_group(host):

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -190,3 +190,33 @@ def test_logging_paths(host, path, path_type, user, group, mode):
     assert current_path.user == user
     assert current_path.group == group
     assert current_path.mode == mode
+
+
+@pytest.mark.parametrize('path,user,group', [
+    ('/var/lib/airflow/airflow/dags/cob_datapipeline/requirements.txt',
+     'airflow', 'airflow')
+    ])
+def test_pipfile_create(host, path, user, group):
+    """
+    Tests DAG in defaults converts Pipfile to requirements.txt
+    """
+    current_path = host.file(path)
+
+    assert current_path.exists
+    assert current_path.is_file
+    assert current_path.user == user
+    assert current_path.group == group
+
+
+@pytest.mark.parametrize('library', [
+    ('xmltodict'),
+    ('pexpect')
+])
+def test_dags_pip_libraries(host, library):
+    """
+    Test DAGs' required pip libraries installed
+    """
+
+    pip_path = "/var/lib/airflow/venv/bin/pip3.6"
+    libraries = host.pip_package.get_packages(pip_path=pip_path)
+    assert libraries.get(library)

--- a/tasks/manage_connections.yml
+++ b/tasks/manage_connections.yml
@@ -26,18 +26,20 @@
 
 - name: 'CONFIG | CONNECTIONS | Add connections without extra settings'
   command: >
-    {{ airflow_virtualenv }}/bin/airflow connections --add --conn_id {{ item.conn_id }} --conn_uri {{ item.conn_uri }}
+    {{ airflow_virtualenv }}/bin/airflow connections --add \
+    --conn_id {{ item.conn_id }} --conn_uri {{ item.conn_uri }}
   changed_when: false
   no_log: True
   with_items: "{{ airflow_connections }}"
-  when: "(item.conn_extra | not(default('')))"
+  when: "(item.conn_extra | default('')) | length > 0"
 
 
 - name: 'CONFIG | CONNECTIONS | Add connections with extra settings'
   command: >
-    {{ airflow_virtualenv }}/bin/airflow connections --add --conn_id {{ item.conn_id }} --conn_uri {{ item.conn_uri }} \
-      --conn_extra {{ item.conn_extra | quote }}
+    {{ airflow_virtualenv }}/bin/airflow connections --add \
+    --conn_id {{ item.conn_id }} --conn_uri {{ item.conn_uri }} \
+    --conn_extra {{ item.conn_extra | quote }}
   changed_when: false
   no_log: True
   with_items: "{{ airflow_connections }}"
-  when: "(item.conn_extra | default(''))"
+  when: "(item.conn_extra | default('')) | length > 0"

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -1,7 +1,6 @@
 ---
 
 # For Listed DAG Git Repos, clone designated branch or release to DAGS folder
-
 - name: 'CONFIG | DAGS | Clone listed DAG git repositories'
   become_user: "{{ airflow_user_name }}"
   become: true
@@ -13,3 +12,31 @@
     version: "{{ item.branch_or_release }}"
   with_items:
     - "{{ dags_git_repositories }}"
+
+
+# Convert Pipfile to Requirements File
+- name: 'CONFIG | DAGS | Convert Pipfile to requirements.txt'
+  become_user: "{{ airflow_user_name }}"
+  become: true
+  args:
+    chdir: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}"
+  shell: >
+    {{ airflow_virtualenv }}/bin/pipenv lock -r > requirements.txt
+  with_items: "{{ dags_git_repositories }}"
+  ignore_errors: true
+  environment:
+    LC_ALL: "en_US.utf-8"
+    LANG: "en_US.utf-8"
+  when: (item.pipfile | bool)
+
+
+# Install DAG Pip packages from requirements.txt
+- name: 'CONFIG | DAGS | Install Pip Packages from requirements.txt'
+  become_user: "{{ airflow_user_name }}"
+  become: true
+  pip:
+    requirements: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}/requirements.txt"
+    virtualenv: "{{ airflow_virtualenv }}"
+    virtualenv_python: "{{ airflow_python_version }}"
+  with_items: "{{ dags_git_repositories }}"
+  when: (item.pip_requirements | bool) or (item.pipfile | bool)


### PR DESCRIPTION
What this PR does:
- adds DAG management task to install DAG pip libraries when Pipfile or requirements.txt file are present
- add Pipenv as install requirement for airflow

This is a really ugly way to handle it, but we're limited by Airflow (a python application) already running in a virtualenv for its own core application management. The end goal is this and airflow playbooks (where we install rbenv, ruby, non-python requirements) will instead all user the Docker Operator and we use Docker + Dockerfiles for DAG task environment spin-up & orchestration.

Blocks tulibraries/ansible-playbook-airflow#27
Blocks tulibraries/ansible-playbook-airflow#28