### PR TITLE
fixing add connection tasks to take all avail airflow cli options

### DIFF
--- a/tasks/manage_connections.yml
+++ b/tasks/manage_connections.yml
@@ -29,7 +29,14 @@
 - name: 'CONFIG | CONNECTIONS | Add connections without extra settings'
   command: >
     {{ airflow_virtualenv }}/bin/airflow connections --add \
-    --conn_id {{ item.conn_id }} --conn_uri {{ item.conn_uri }}
+    --conn_id {{ item.conn_id }} \
+    --conn_uri {{ item.conn_uri | default('') | quote }} \
+    --conn_type {{ item.conn_type | default('') | quote }} \
+    --conn_host {{ item.conn_host | default('') | quote }} \
+    --conn_login {{ item.conn_login | default('') | quote }} \
+    --conn_password {{ item.conn_password | default('') | quote }} \
+    --conn_schema {{ item.conn_schema | default('') | quote }} \
+    --conn_port {{ item.conn_port | default('') | quote }} \
   changed_when: false
   no_log: True
   with_items: "{{ airflow_connections }}"
@@ -39,7 +46,14 @@
 - name: 'CONFIG | CONNECTIONS | Add connections with extra settings'
   command: >
     {{ airflow_virtualenv }}/bin/airflow connections --add \
-    --conn_id {{ item.conn_id }} --conn_uri {{ item.conn_uri }} \
+    --conn_id {{ item.conn_id }} \
+    --conn_uri {{ item.conn_uri | default('') | quote }} \
+    --conn_type {{ item.conn_type | default('') | quote }} \
+    --conn_host {{ item.conn_host | default('') | quote }} \
+    --conn_login {{ item.conn_login | default('') | quote }} \
+    --conn_password {{ item.conn_password | default('') | quote }} \
+    --conn_schema {{ item.conn_schema | default('') | quote }} \
+    --conn_port {{ item.conn_port | default('') | quote }} \
     --conn_extra {{ item.conn_extra | quote }}
   changed_when: false
   no_log: True


### PR DESCRIPTION
What this PR does:

- soften expectations / hard-coding of ansible connections setup at the role level
- allows passing other airflow connections CLI options to ansible playbook(s)

Not a rush, but nice to get in to represent latest state of Airflow work.