### PR TITLE
Fix connections task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ deploy:
   on:
     repo: tulibraries/ansible-role-airflow
     tags: true
-    branch: master
+    branch:
+      - master
+      - /v\d+\.\d+[a-z]/
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ after_success:
   - true
 
 before_deploy:
-  - if [ -n "$TRAVIS_TAG" -a "$TRAVIS_BRANCH" = "master" ]; git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
-  - if [ -n "$TRAVIS_TAG" -a "$TRAVIS_BRANCH" = "master" ]; git archive HEAD -o $TRAVIS_TAG.zip; fi
+  - if [ -n "$TRAVIS_TAG" ]; git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
+  - if [ -n "$TRAVIS_TAG" ]; git archive HEAD -o $TRAVIS_TAG.zip; fi
 
 deploy:
   provider: releases
@@ -34,7 +34,7 @@ deploy:
     tags: true
     branch:
       - master
-      - /v\d+\.\d+[a-z]/
+      - /^v.*$/
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ after_success:
   - true
 
 before_deploy:
-  - if [ -n "$TRAVIS_TAG" ]; git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
-  - if [ -n "$TRAVIS_TAG" ]; git archive HEAD -o $TRAVIS_TAG.zip; fi
+  - if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
+  - if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.zip; fi
 
 deploy:
   provider: releases

--- a/tasks/manage_connections.yml
+++ b/tasks/manage_connections.yml
@@ -26,36 +26,50 @@
   when: 'item.conn_id in airflow_existing_connections.stdout_lines'
 
 
-- name: 'CONFIG | CONNECTIONS | Add connections without extra settings'
+- name: 'CONFIG | CONNECTIONS | Add connections using conn_uri'
   command: >
     {{ airflow_virtualenv }}/bin/airflow connections --add \
     --conn_id {{ item.conn_id }} \
     --conn_uri {{ item.conn_uri | default('') | quote }} \
+    --conn_extra {{ item.conn_extra | default('') | quote }}
+  changed_when: false
+  no_log: True
+  with_items: "{{ airflow_connections }}"
+  when: "(item.conn_uri | default('')) | length > 0"
+
+
+- name: 'CONFIG | CONNECTIONS | Add connections not using conn_uri with port'
+  command: >
+    {{ airflow_virtualenv }}/bin/airflow connections --add \
+    --conn_id {{ item.conn_id }} \
     --conn_type {{ item.conn_type | default('') | quote }} \
     --conn_host {{ item.conn_host | default('') | quote }} \
     --conn_login {{ item.conn_login | default('') | quote }} \
     --conn_password {{ item.conn_password | default('') | quote }} \
     --conn_schema {{ item.conn_schema | default('') | quote }} \
-    --conn_port {{ item.conn_port | default('') | quote }} \
+    --conn_extra {{ item.conn_extra | default('') | quote }}
   changed_when: false
   no_log: True
   with_items: "{{ airflow_connections }}"
-  when: "(item.conn_extra | default('')) | length == 0"
+  when:
+    - "(item.conn_uri | default('')) | length == 0"
+    - "(item.conn_port | default(0)) | int == 0"
 
 
-- name: 'CONFIG | CONNECTIONS | Add connections with extra settings'
+- name: 'CONFIG | CONNECTIONS | Add connections not using conn_uri without port'
   command: >
     {{ airflow_virtualenv }}/bin/airflow connections --add \
     --conn_id {{ item.conn_id }} \
-    --conn_uri {{ item.conn_uri | default('') | quote }} \
     --conn_type {{ item.conn_type | default('') | quote }} \
     --conn_host {{ item.conn_host | default('') | quote }} \
     --conn_login {{ item.conn_login | default('') | quote }} \
     --conn_password {{ item.conn_password | default('') | quote }} \
     --conn_schema {{ item.conn_schema | default('') | quote }} \
-    --conn_port {{ item.conn_port | default('') | quote }} \
-    --conn_extra {{ item.conn_extra | quote }}
+    --conn_port {{ item.conn_port }} \
+    --conn_extra {{ item.conn_extra | default('') | quote }}
   changed_when: false
   no_log: True
   with_items: "{{ airflow_connections }}"
-  when: "(item.conn_extra | default('')) | length > 0"
+  when:
+    - "(item.conn_uri | default('')) | length == 0"
+    - "(item.conn_port | default(0)) | int > 0"


### PR DESCRIPTION
What this PR does:

- updates Travis for fuller Github Releases deploy based on release tags
- updates Airflow Connections tasks for handling `conn_uri` vs `conn_type` (plus all other options), and handling `conn_port` integer fails when not provided