### PR TITLE
adding DAG-related git clone action for code not in DAGs dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ tests/roles/
 
 # Molecule
 .molecule
+
+# Travis / CI related
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,33 @@
----
 language: python
 python:
-  - "3.6"
+- '3.6'
 services:
-  - docker
-
+- docker
 install:
-  - pip install pipenv
-  - pipenv install --dev
-
+- pip install pipenv
+- pipenv install --dev
 script:
-  - pipenv run molecule test
-
+- pipenv run molecule test
 after_success:
-  - true
-
+- true
 before_deploy:
-  - if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
-  - if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.zip; fi
-
+- if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
+- if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.zip; fi
 deploy:
   provider: releases
   skip_cleanup: true
   prerelease: true
-  name: $TRAVIS_TAG release
+  name: "$TRAVIS_TAG release"
   file:
-    - $TRAVIS_TAG.tar.gz
-    - $TRAVIS_TAG.zip
+  - "$TRAVIS_TAG.tar.gz"
+  - "$TRAVIS_TAG.zip"
   api_key:
-    secure: QBfV53ur+n61pruhD30PD8CCp3R+M5fnl8+7J2vy7tzyspvtRMs3x9nJTihHAZ0Y4qjZ+fvQ2RsW80hONlMi+DaY+vrEqhhjZ4YHicaJV/tWzGAq4R6YjcA98OpW94R7i1LSMBh0+ncXzzLZnQeR/NzB7co1gkIXV5tKXZLQsL11Oz7cuJGGrFVdfhTXDgl+zTigno6nvyXHpSqDAoZ3p16wyp7vYtJicEkWa+YwsdYCnwuLjOg8jwrOvsUopH1UOnqRv5tOaFM01uXUIJqNU/Uy3AaaH7nD9J4pYhe9tHSSeITnsdiTa53IFVZrcVwrvZYftp9mGjCKQiZohDHvOJbQbSv2AojTRPeEYfum14+0kBYQmiRRVh5L2geEddXA7kU9waSF1GO9YvCJrEtDIfLTioxJXUxD0i5u2pq+ZJ0JV7D9WLdq54dR28tHZYXwOxe2WnwhCaax/WivFoYvtIL1FXybJcEF9d9tZCLgNUbABaLSfBrVQQ55Tx0mKqHQOccy3+E5t9PLVG6CFK2b9n5iogrnkOaz49/2cmVHYqiQwp1KYzYvCs7At9sTMv0+jlblVEikKuLSwpiyMszWpcAk8g8T236FwXxrBEHXnfuDjmrHxjK9HX91C16gTjeyu68T4XVVUbYTNsWLNEsJEnmIXrmhuy+EHoayIWrkk3w=
+    secure: AGUiZgxfZVG5c6EvV+n6malKxO3BNDDRfJiHpW+G9zMGnZNTL4Vmmn3tM/rVZ9jvcYHE6nbTvS1GiFftKZ34i/PPgWFeMAUXeX4S8vMXDIpB9V2X9tfTnRxpdMGZtnPL/m2e7ThNXH5djY4W/bAIb/3EcezK5mTDiaLfq0A2DfhYLXoqEprv21Nz1Mq9cP5rpZAMgdv0MYKjovZF3+hyVVkz3hEdDMHgPD/tFszfF3k1T2LVNkvYcq9lEAeJ51BG1hp2vbokd2SBKamyq+S6VvKpN8ysijWVO7CRseXmEbocksDgOi2iBZ/4aalflm/bt/rg0vY75DEwtQ7+ErXkcGU/ojeyRkgWayLdifkcSUqMRsnrmQngGSPEABMV2FThuafdvywZ4WHoqPQls0a2yxJI+nZ38dzCQZ64dTgexGAyCs/goPmmhINloNlFgUI2B6FK42CKXg8xov/PlM/ev20P7Prjk3IuR5PIDWENU2CEXkFYj8A750AXoRVu+BrN37h1xUFA1O92xs2mvjScELxN/t9xGyFKRzLCoufM9sMU4NtZOF5M6sBfioyQvq70Suk96TaZTPTaP5ZuUlkIoDATpsmd4yDa3QiVvlKg+oxvWoG4zyTERAX2H7MtXUisFEEc09wV3ee5/XyCdiK5rZ/OdnHZpXziSE5xHdhXbK4=
   on:
     repo: tulibraries/ansible-role-airflow
     tags: true
     branch:
-      - master
-      - /^v.*$/
-
+    - master
+    - "/^v.*$/"
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,40 @@
+---
 language: python
 python:
-- '3.6'
+  - "3.6"
 services:
-- docker
+  - docker
+
 install:
-- pip install pipenv
-- pipenv install --dev
+  - pip install pipenv
+  - pipenv install --dev
+
 script:
-- pipenv run molecule test
+  - pipenv run molecule test
+
 after_success:
-- true
+  - true
+
 before_deploy:
-- if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
-- if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.zip; fi
+  - if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.tar.gz; fi
+  - if [ -n "$TRAVIS_TAG" ]; then git archive HEAD -o $TRAVIS_TAG.zip; fi
+
 deploy:
   provider: releases
   skip_cleanup: true
   prerelease: true
-  name: "$TRAVIS_TAG release"
+  name: $TRAVIS_TAG release
   file:
-  - "$TRAVIS_TAG.tar.gz"
-  - "$TRAVIS_TAG.zip"
+    - $TRAVIS_TAG.tar.gz
+    - $TRAVIS_TAG.zip
   api_key:
     secure: AGUiZgxfZVG5c6EvV+n6malKxO3BNDDRfJiHpW+G9zMGnZNTL4Vmmn3tM/rVZ9jvcYHE6nbTvS1GiFftKZ34i/PPgWFeMAUXeX4S8vMXDIpB9V2X9tfTnRxpdMGZtnPL/m2e7ThNXH5djY4W/bAIb/3EcezK5mTDiaLfq0A2DfhYLXoqEprv21Nz1Mq9cP5rpZAMgdv0MYKjovZF3+hyVVkz3hEdDMHgPD/tFszfF3k1T2LVNkvYcq9lEAeJ51BG1hp2vbokd2SBKamyq+S6VvKpN8ysijWVO7CRseXmEbocksDgOi2iBZ/4aalflm/bt/rg0vY75DEwtQ7+ErXkcGU/ojeyRkgWayLdifkcSUqMRsnrmQngGSPEABMV2FThuafdvywZ4WHoqPQls0a2yxJI+nZ38dzCQZ64dTgexGAyCs/goPmmhINloNlFgUI2B6FK42CKXg8xov/PlM/ev20P7Prjk3IuR5PIDWENU2CEXkFYj8A750AXoRVu+BrN37h1xUFA1O92xs2mvjScELxN/t9xGyFKRzLCoufM9sMU4NtZOF5M6sBfioyQvq70Suk96TaZTPTaP5ZuUlkIoDATpsmd4yDa3QiVvlKg+oxvWoG4zyTERAX2H7MtXUisFEEc09wV3ee5/XyCdiK5rZ/OdnHZpXziSE5xHdhXbK4=
   on:
     repo: tulibraries/ansible-role-airflow
     tags: true
     branch:
-    - master
-    - "/^v.*$/"
+      - master
+      - /^v.*$/
+
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -276,6 +276,10 @@ dags_git_repositories:
     branch_or_release: "master"
     pipfile: true
     pip_requirements: false
+dags_git_repositories:
+  - repo: "https://github.com/tulibraries/tul_cob.git"
+    dest_folder: "$HOME/tul_cob"
+    branch_or_release: "master"
 
 airflow_dag_system_dependencies:
   - name: "@Development tools"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -276,7 +276,7 @@ dags_git_repositories:
     branch_or_release: "master"
     pipfile: true
     pip_requirements: false
-dags_git_repositories:
+dags_related_git_repositories:
   - repo: "https://github.com/tulibraries/tul_cob.git"
     dest_folder: "$HOME/tul_cob"
     branch_or_release: "master"

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -13,6 +13,19 @@
   with_items:
     - "{{ dags_git_repositories }}"
 
+# For DAG-Related Git Repos, clone designated branch or release to $HOME
+- name: 'CONFIG | DAGS | Clone listed DAG-related git repositories'
+  become_user: "{{ airflow_user_name }}"
+  become: true
+  git:
+    repo: "{{ item.repo }}"
+    dest: "{{ item.dest_folder }}"
+    clone: true
+    force: true
+    version: "{{ item.branch_or_release }}"
+  with_items:
+    - "{{ dags_git_related_repositories }}"
+
 
 # Convert Pipfile to Requirements File
 - name: 'CONFIG | DAGS | Convert Pipfile to requirements.txt'

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -24,7 +24,7 @@
     force: true
     version: "{{ item.branch_or_release }}"
   with_items:
-    - "{{ dags_git_related_repositories }}"
+    - "{{ dags_related_git_repositories }}"
 
 
 # Convert Pipfile to Requirements File


### PR DESCRIPTION
What this PR does:
- creates a task & default variable for closing DAG-related code that doesn't go into the DAGs directory

Primary need: cloning / resetting tul_cob for cob_datapipeline between deploys