### PR TITLE
Link to dags outside the repo dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -129,6 +129,7 @@ airflow_config_template: "templates/airflow.cfg.j2"
 airflow_defaults_config:
   core:
     airflow_home_mode: "0700"
+    dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
     dags_folder: "{{ airflow_user_home_path ~ '/airflow/dags' }}"
     dags_folder_mode: "0755"
     base_log_folder: "{{ airflow_log_path }}"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,3 +4,12 @@
   hosts: all
   roles:
     - role: ansible-role-airflow
+      dags_git_repositories:
+        - repo: "https://github.com/tulibraries/cob_datapipeline.git"
+          dest_folder: "cob_datapipeline"
+          branch_or_release: "qa"
+          pipfile: true
+          pip_requirements: false
+      airflow_extra_packages:
+        - name: 'apache-airflow[crypto]'
+        - name: 'werkzeug>=0.15.0,<1.0.0'

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -219,6 +219,7 @@ def test_dags_pip_libraries(host, library):
 
     pip_path = "/var/lib/airflow/venv/bin/pip3.6"
     libraries = host.pip_package.get_packages(pip_path=pip_path)
+    print(libraries)
     assert libraries.get(library)
 
 

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -20,7 +20,7 @@
   file:
     state: link
     path: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}"
-    src: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name}}{% endif %}"
+    src: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name }}{% endif %}"
   with_items:
     - "{{ dags_git_repositories }}"
 

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -6,10 +6,21 @@
   become: true
   git:
     repo: "{{ item.repo }}"
-    dest: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}"
+    dest: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}"
     clone: true
     force: true
     version: "{{ item.branch_or_release }}"
+  with_items:
+    - "{{ dags_git_repositories }}"
+
+# FOR Listed DAG Git Repos, link them from download destination to configured DAGS folder
+- name: 'CONFIG | DAGS | Link dag repository to dags folder'
+  become_user: "{{ airflow_user_name }}"
+  become: true
+  file:
+    state: link
+    path: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}"
+    src: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name}}{% endif %}"
   with_items:
     - "{{ dags_git_repositories }}"
 

--- a/tasks/manage_installation.yml
+++ b/tasks/manage_installation.yml
@@ -81,7 +81,7 @@
     SLUGIFY_USES_TEXT_UNIDECODE: "yes"
   when: (not airflow_pip_custom_version_install) or
       (item.version is not defined) or
-      ( (not item.version | search('<') ) and (not item.version | search('>') ) )
+      ( (not item.version is search('<') ) and (not item.version is search('>') ) )
 
 # Install airflow packages
 # Ansible's pip module doesn't currently support complex version strings
@@ -94,7 +94,7 @@
   with_items: "{{ airflow_packages }}"
   when: (airflow_pip_custom_version_install) and
         (item.version is defined) and
-      ( (item.version | search('<') ) or (item.version | search('>') ) )
+      ( (item.version is search('<') ) or (item.version is search('>') ) )
 
 # Install airflow extra packages
 - name: 'INSTALL | Manage airflow extra packages installation'


### PR DESCRIPTION
This indirection allows us to link to a folder within a dag repository, or to the repo directly, while still managing the dag repos via git.

Additionally, switches to usng `is` instead of `|` for managing airflow installation.
 