### PR TITLE
Only deploy dag repos if they have a branch defined

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -7,7 +7,12 @@
       dags_git_repositories:
         - repo: "https://github.com/tulibraries/cob_datapipeline.git"
           dest_folder: "cob_datapipeline"
-          branch_or_release: "qa"
+          branch_or_release: "master"
+          pipfile: true
+          pip_requirements: false
+        - repo: "https://github.com/tulibraries/funcake_dags.git"
+          dest_folder: "funcake_dags"
+          branch_or_release: ""
           pipfile: true
           pip_requirements: false
       airflow_extra_packages:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -170,6 +170,18 @@ def test_airflow_dags_paths(host, path):
     assert current_path.is_directory
 
 
+@pytest.mark.parametrize('path', [
+    ('/var/lib/airflow/airflow/dags/funcake_dags/'),
+    ])
+def test_undefined_branch_airflow_dags_paths(host, path):
+    """
+    Tests that a dag without a defined branch is not deployed
+    """
+    current_path = host.file(path)
+
+    assert not current_path.exists
+
+
 @pytest.mark.parametrize('path,path_type,user,group,mode', [
     ('/var/log/airflow', 'directory', 'airflow', 'airflow', 0o700),
     ('/var/run/airflow', 'directory', 'airflow', 'airflow', 0o700),

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -13,6 +13,7 @@
     recursive: false
   with_items:
     - "{{ dags_git_repositories }}"
+  when: (item.branch_or_release | length) > 0
 
 # FOR Listed DAG Git Repos, link them from download destination to configured DAGS folder
 - name: 'CONFIG | DAGS | Link dag repository to dags folder'
@@ -24,6 +25,7 @@
     src: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name }}{% endif %}"
   with_items:
     - "{{ dags_git_repositories }}"
+  when: (item.branch_or_release | length) > 0
 
 # For DAG-Related Git Repos, clone designated branch or release to $HOME
 - name: 'CONFIG | DAGS | Clone listed DAG-related git repositories'
@@ -52,7 +54,7 @@
   environment:
     LC_ALL: "en_US.utf-8"
     LANG: "en_US.utf-8"
-  when: (item.pipfile | bool)
+  when: (((item.branch_or_release | length) > 0) and (item.pipfile | bool))
 
 
 # Install DAG Pip packages from requirements.txt
@@ -64,7 +66,7 @@
     virtualenv: "{{ airflow_virtualenv }}"
     virtualenv_python: "{{ airflow_python_version }}"
   with_items: "{{ dags_git_repositories }}"
-  when: (item.pip_requirements | bool) or (item.pipfile | bool)
+  when: (((item.branch_or_release | length) > 0) and ((item.pip_requirements | bool) or (item.pipfile | bool)))
 
 
 # Manage DAGs system dependencies


### PR DESCRIPTION
This will allow us to defer deployments of individual dag repos at the
inventory level.