### PR TITLE
DEVO-285 Fix linter errors

### DIFF
--- a/tasks/manage_airflow_variables.yml
+++ b/tasks/manage_airflow_variables.yml
@@ -40,6 +40,7 @@
   copy:
     content: "{{ merged_variables | to_json }}"
     dest: /tmp/merged_variables.json
+    mode: 0644
 
 
 - name: 'CONFIG | VARIABLES | Import variables from file'

--- a/tasks/manage_installation.yml
+++ b/tasks/manage_installation.yml
@@ -63,6 +63,7 @@
   template:
     src: "{{ airflow_profiled_template }}"
     dest: "/etc/profile.d/airflow.sh"
+    mode: 0644
   when: airflow_provide_user_env
 
 # Install airflow packages


### PR DESCRIPTION
- Fixes linter errors by explicitly setting file permissions (tested role in vagrant and the tasks were successful)