### PR TITLE
Fix broken configuration.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -197,14 +197,13 @@ airflow_defaults_config:
   scheduler:
     job_heartbeat_sec: 5
     log_file: "{{ airflow_log_path }}/airflow-scheduler.log"
-    num_runs: 0
     pid: "{{ airflow_pid_path }}/airflow-scheduler.pid"
     scheduler_heartbeat_sec: 5
     statsd_on: False
     statsd_host: 'localhost'
     statsd_port: 8125
     statsd_prefix: 'airflow'
-    max_threads: 2
+    parsing_processes: 2
 
   mesos:
     master: 'localhost:5050'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,7 @@ airflow_packages:
   - name: 'Cython'
     version: '0.28.2'
   - name: 'apache-airflow'
-    version: '1.9.0'
+    version: '1.10.14'
   - name: 'pipenv'
 airflow_extra_packages:
   - name: 'apache-airflow[crypto]'


### PR DESCRIPTION
"num_runs" was set in 1.10.6 and it needs to be greater than 0 or it causes
scheduler to restart in a forever loop.

"max_threads" is deprecated and has been changed to "parsing_processes"

closes #27