### PR TITLE
DEVO-570 Move dags_repos_folder out of airflow core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
       - run:
           name: Install
           command: pipenv install --dev
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - run:
           name: Molecule
           command: pipenv run molecule test

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ airflow_virtualenv_mode: "0755"
 airflow_python_version: "{{ _airflow_python_version }}"
 python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
-airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
+airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-4/constraints-3.9.txt"
 dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
 
 airflow_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,7 @@ airflow_python_version: "{{ _airflow_python_version }}"
 python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
 airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
+dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
 
 airflow_packages:
   - name: 'GitPython'
@@ -131,7 +132,6 @@ airflow_config_template: "templates/airflow.cfg.j2"
 airflow_defaults_config:
   core:
     airflow_home_mode: "0700"
-    dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
     dags_folder: "{{ airflow_user_home_path ~ '/airflow/dags' }}"
     dags_folder_mode: "0755"
     base_log_folder: "{{ airflow_log_path }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,14 +39,14 @@ airflow_virtualenv_mode: "0755"
 airflow_python_version: "{{ _airflow_python_version }}"
 python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
-airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-4/constraints-3.9.txt"
+airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
 dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
 
 airflow_packages:
   - name: 'GitPython'
   - name: 'Cython'
   - name: 'apache-airflow'
-    version: '2.4.1'
+    version: '2.3.4'
   - name: 'pipenv'
   - name: 'numpy'
 airflow_extra_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,14 +39,14 @@ airflow_virtualenv_mode: "0755"
 airflow_python_version: "{{ _airflow_python_version }}"
 python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
-airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
+airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-4/constraints-3.9.txt"
 dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
 
 airflow_packages:
   - name: 'GitPython'
   - name: 'Cython'
   - name: 'apache-airflow'
-    version: '2.3.0'
+    version: '2.4.1'
   - name: 'pipenv'
   - name: 'numpy'
 airflow_extra_packages:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ airflow_packages:
   - name: 'pipenv'
   - name: 'numpy'
 airflow_extra_packages:
-  - name: 'apache-airflow[crypto]'
+  - name: 'apache-airflow[amazon]'
 
 dag_packages: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ airflow_virtualenv_mode: "0755"
 airflow_python_version: "{{ _airflow_python_version }}"
 python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
-airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-4/constraints-3.9.txt"
+airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
 dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
 
 airflow_packages:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,8 +12,8 @@
           dest_folder: "funcake_dags"
           branch_or_release: ""
       airflow_extra_packages:
-        - name: 'apache-airflow[crypto]'
-        - name: 'werkzeug==1.0.1'
+        - name: 'apache-airflow[amazon]'
+        - name: 'werkzeug==2.2.2'
   vars:
     airflow_fernet_key: '46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho='
     python_version: '3.9.10'

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -6,7 +6,7 @@
   become: true
   git:
     repo: "{{ item.repo }}"
-    dest: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}"
+    dest: "{{ dags_repos_folder }}/{{ item.dest_folder }}"
     clone: true
     force: true
     version: "{{ item.branch_or_release }}"
@@ -22,7 +22,7 @@
   file:
     state: link
     path: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}"
-    src: "{{ airflow_config.core.dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name }}{% endif %}"
+    src: "{{ dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name }}{% endif %}"
   with_items:
     - "{{ dags_git_repositories }}"
   when: (item.branch_or_release | length) > 0


### PR DESCRIPTION
We are running into an issue when attempting to deploy changes from the dags repositories without running the whole playbook.  We hit an error during the git clone task that starts with {"msg": "The task includes an option with an undefined variable.}

Looking at the airflow core configuration, it does not appear that dags_repos_folder is a valid configuration for airflow.core.  Moving this variable out of the core configuration allowed the tasks to run successfully in a vagrant session.