### PR TITLE
DEVO-570 Rename one more dag variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,7 @@ python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
 airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
 dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
+dags_folder: "{{ airflow_user_home_path ~ '/airflow/dags' }}"
 
 airflow_packages:
   - name: 'GitPython'

--- a/tasks/manage_dags.yml
+++ b/tasks/manage_dags.yml
@@ -21,7 +21,7 @@
   become: true
   file:
     state: link
-    path: "{{ airflow_config.core.dags_folder }}/{{ item.dest_folder }}"
+    path: "{{ dags_folder }}/{{ item.dest_folder }}"
     src: "{{ dags_repos_folder }}/{{ item.dest_folder }}{% if item.dags_folder_name is defined %}/{{ item.dags_folder_name }}{% endif %}"
   with_items:
     - "{{ dags_git_repositories }}"


### PR DESCRIPTION
Whe we are running the deployments for dag_repository changes, they do not have access to airflow core variables, so the process breaks.  This moves the variable outside of core so that we don't have to run the whole playbook when pushing dag_repo changes.