### PR TITLE
Devo 885 update airflow commands

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ airflow_virtualenv_mode: "0755"
 airflow_python_version: "{{ _airflow_python_version }}"
 python_version: "3.9.10"
 # Update if python version or apache airflow version changes.
-airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2-3/constraints-3.9.txt"
+airflow_python_constraint: "--constraint=https://raw.githubusercontent.com/apache/airflow/constraints-2.7.1/constraints-3.9.txt"
 dags_repos_folder: "{{ airflow_user_home_path ~ '/airflow/dags_repos' }}"
 dags_folder: "{{ airflow_user_home_path ~ '/airflow/dags' }}"
 
@@ -47,7 +47,7 @@ airflow_packages:
   - name: 'GitPython'
   - name: 'Cython'
   - name: 'apache-airflow'
-    version: '2.3.4'
+    version: '2.7.1'
   - name: 'pipenv'
   - name: 'numpy'
 airflow_extra_packages:
@@ -122,10 +122,6 @@ airflow_manage_database: true
 airflow_database_engine: 'mysql'
 airflow_database_sqlite_file_path: "{{ airflow_user_home_path ~ '/airflow/airflow.db' }}"
 
-# Set do_init to false if database already initialized
-airflow_do_init_db: true
-airflow_do_upgrade_db: true
-
 airflow_webserver_authenticate: false
 
 # Default configuration
@@ -193,7 +189,7 @@ airflow_defaults_config:
     smtp_mail_from: 'airflow@airflow.com'
 
   celery:
-    celery_app_name: 'airflow.executors.celery_executor'
+    celery_app_name: 'airflow.providers.celery.executors.celery_executor'
     worker_concurrency: 16
     worker_log_server_port: 8793
     broker_url: 'sqla+mysql://airflow:airflow@localhost:3306/airflow'
@@ -204,6 +200,7 @@ airflow_defaults_config:
   scheduler:
     job_heartbeat_sec: 5
     log_file: "{{ airflow_log_path }}/airflow-scheduler.log"
+    max_tis_per_query: 0
     pid: "{{ airflow_pid_path }}/airflow-scheduler.pid"
     scheduler_heartbeat_sec: 5
     statsd_on: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -13,7 +13,7 @@
           branch_or_release: ""
       airflow_extra_packages:
         - name: 'apache-airflow[amazon]'
-        - name: 'werkzeug==2.2.2'
+        - name: 'werkzeug'
   vars:
     airflow_fernet_key: '46BKJoQYlPPOexq0OhDZnIlNepKFf87WFwLbfzqDDho='
     python_version: '3.9.10'

--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -61,15 +61,11 @@
 
 
 # Manage database initialize if first deployment
-- name: 'CONFIG | Manage database initialize'
+- name: 'CONFIG | Manage database creation or upgrade'
   become_user: "{{ airflow_user_name }}"
   become: true
-  command: "{{ airflow_virtualenv }}/bin/airflow db init"
+  command: "{{ airflow_virtualenv }}/bin/airflow db migrate"
   run_once: true
-  when:
-    - "not airflow_config_stat.stat.exists"
-    - "airflow_do_init_db | bool"
-
 
 # Set Sqlite backend permissions
 - name: 'CONFIG | Ensure SQLite backend file has good permissions'
@@ -80,18 +76,6 @@
     state: 'file'
   when:
     - "airflow_database_engine == 'sqlite'"
-
-
-# Manage database upgrade if there are migrations to run
-- name: 'CONFIG | Manage database upgrade'
-  become_user: "{{ airflow_user_name }}"
-  become: true
-  shell: "{{ airflow_virtualenv }}/bin/airflow db check-migrations || {{ airflow_virtualenv }}/bin/airflow db upgrade || true"
-  run_once: true
-  when:
-    - "airflow_config_stat.stat.exists"
-    - "airflow_do_upgrade_db | bool"
-
 
 # If airflow_*_config.webserver.authentication: True
 # add airflow_admin users to airflow


### PR DESCRIPTION
Updates airflow role to be compatible with Airflow 2.7.  Changes include:
* Updating the db commands (they only use migrate, init and upgrade were removed)
* Updates the celery_app_name
* Updates airflow version and constraints file