### PR TITLE
Remove ref to variable that no longer exists

### DIFF
--- a/tasks/manage_configuration.yml
+++ b/tasks/manage_configuration.yml
@@ -94,7 +94,6 @@
             --password {{ item.airflow_dummy_password }} "
   when:
     - "airflow_webserver_authenticate | bool"
-    - "airflow_do_init_db | bool"
   with_items: "{{ airflow_webserver_admins }}"
   tags:
     - "add_users"


### PR DESCRIPTION
Now that there is only a db migrate command, it doesn't make sense to have an airflow_do_init_db variable.